### PR TITLE
Add npm start script for http-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This repository contains a minimal example of a rotating cube using [Three.js](h
    ```bash
    npm install
    ```
-2. Open `index.html` in a modern web browser. If you are running from a local server, you can use `npx http-server` or any other static server.
+2. Start a local server:
+   ```bash
+   npm start
+   ```
+   Then open the provided URL in your web browser.
 
 The cube will rotate continuously and resize with the browser window.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx http-server ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `npm start` script to serve with `http-server`
- document `npm start` usage in README

## Testing
- `npm test` *(fails: no tests specified)*
- `timeout 2 npm start`

------
https://chatgpt.com/codex/tasks/task_e_6846865db0a883218f094db27f560740