### PR TITLE
Draw tree using lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Three.js Rotating Cube Example
+# Three.js Animated Line Tree Example
 
-This repository contains a minimal example of a rotating cube using [Three.js](https://threejs.org/).
+This repository contains a minimal example that draws a simple tree using line segments in [Three.js](https://threejs.org/). The tree is animated so that each point appears every 0.5 seconds.
 
 ## Usage
 
@@ -14,4 +14,4 @@ This repository contains a minimal example of a rotating cube using [Three.js](h
    ```
    Then open the provided URL in your web browser.
 
-The cube will rotate continuously and resize with the browser window.
+The tree will gradually draw itself and resize with the browser window.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Rotating Cube</title>
+  <title>Line Tree</title>
   <style>
     body { margin: 0; overflow: hidden; }
     canvas { display: block; }
@@ -20,17 +20,45 @@
     renderer.setSize(window.innerWidth, window.innerHeight);
     document.body.appendChild(renderer.domElement);
 
-    const geometry = new THREE.BoxGeometry(1, 1, 1);
-    const material = new THREE.MeshNormalMaterial();
-    const cube = new THREE.Mesh(geometry, material);
-    scene.add(cube);
+    const material = new THREE.LineBasicMaterial({ color: 0x00ff00 });
+    const points = [];
+    points.push(new THREE.Vector3(0, 0, 0));
+    points.push(new THREE.Vector3(0, 1, 0));
 
-    camera.position.z = 2;
+    points.push(new THREE.Vector3(0, 1, 0));
+    points.push(new THREE.Vector3(-0.5, 1.5, 0));
+
+    points.push(new THREE.Vector3(0, 1, 0));
+    points.push(new THREE.Vector3(0.5, 1.5, 0));
+
+    points.push(new THREE.Vector3(-0.5, 1.5, 0));
+    points.push(new THREE.Vector3(-0.75, 2, 0));
+
+    points.push(new THREE.Vector3(-0.5, 1.5, 0));
+    points.push(new THREE.Vector3(-0.25, 2, 0));
+
+    points.push(new THREE.Vector3(0.5, 1.5, 0));
+    points.push(new THREE.Vector3(0.75, 2, 0));
+
+    points.push(new THREE.Vector3(0.5, 1.5, 0));
+    points.push(new THREE.Vector3(0.25, 2, 0));
+
+    const geometry = new THREE.BufferGeometry().setFromPoints(points);
+    geometry.setDrawRange(0, 0); // start with no points drawn
+    const tree = new THREE.LineSegments(geometry, material);
+    scene.add(tree);
+
+    let index = 0;
+    const interval = setInterval(() => {
+      index += 1;
+      geometry.setDrawRange(0, index);
+      if (index >= points.length) clearInterval(interval);
+    }, 500); // 0.5 seconds per point
+
+    camera.position.z = 3;
 
     function animate() {
       requestAnimationFrame(animate);
-      cube.rotation.x += 0.01;
-      cube.rotation.y += 0.01;
       renderer.render(scene, camera);
     }
     animate();


### PR DESCRIPTION
## Summary
- modify the example to display a simple tree drawn with line segments
- animate the tree drawing so each point appears every half second
- update README to reflect the new example

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68469bd020308321aa5d22c579dc13e7